### PR TITLE
Add support for receiving addrv2 messages

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -836,17 +836,16 @@ func (p *Peer) PushAddrMsg(addresses []*wire.NetAddress) ([]*wire.NetAddress, er
 	msg.AddrList = make([]*wire.NetAddress, addressCount)
 	copy(msg.AddrList, addresses)
 
-	// Randomize the addresses sent if there are more than the maximum allowed.
+	// Randomize the addresses sent
+	rand.Shuffle(addressCount, func(i, j int) {
+		msg.AddrList[i], msg.AddrList[j] = msg.AddrList[j], msg.AddrList[i]
+	})
 	if addressCount > wire.MaxAddrPerMsg {
-		// Shuffle the address list.
-		for i := 0; i < wire.MaxAddrPerMsg; i++ {
-			j := i + rand.Intn(addressCount-i)
-			msg.AddrList[i], msg.AddrList[j] = msg.AddrList[j], msg.AddrList[i]
-		}
-
-		// Truncate it to the maximum size.
-		msg.AddrList = msg.AddrList[:wire.MaxAddrPerMsg]
+		addressCount = wire.MaxAddrPerMsg
 	}
+
+	// Truncate it to the maximum size.
+	msg.AddrList = msg.AddrList[:addressCount]
 
 	p.QueueMessage(msg, nil)
 	return msg.AddrList, nil
@@ -865,17 +864,16 @@ func (p *Peer) PushAddrV2Msg(addresses []*wire.NetAddressV2) ([]*wire.NetAddress
 	msg.AddrList = make([]*wire.NetAddressV2, addressCount)
 	copy(msg.AddrList, addresses)
 
-	// Randomize the addresses sent if there are more than the maximum allowed.
+	// Randomize the addresses sent
+	rand.Shuffle(addressCount, func(i, j int) {
+		msg.AddrList[i], msg.AddrList[j] = msg.AddrList[j], msg.AddrList[i]
+	})
 	if addressCount > wire.MaxAddrPerMsg {
-		// Shuffle the address list.
-		for i := 0; i < wire.MaxAddrPerMsg; i++ {
-			j := i + rand.Intn(addressCount-i)
-			msg.AddrList[i], msg.AddrList[j] = msg.AddrList[j], msg.AddrList[i]
-		}
-
-		// Truncate it to the maximum size.
-		msg.AddrList = msg.AddrList[:wire.MaxAddrPerMsg]
+		addressCount = wire.MaxAddrPerMsg
 	}
+
+	// Truncate it to the maximum size.
+	msg.AddrList = msg.AddrList[:addressCount]
 
 	p.QueueMessage(msg, nil)
 	return msg.AddrList, nil

--- a/wire/common.go
+++ b/wire/common.go
@@ -324,6 +324,14 @@ func readElement(r io.Reader, element interface{}) error {
 		}
 		*e = RejectCode(rv)
 		return nil
+
+	case *NetworkID:
+		rv, err := binarySerializer.Uint8(r)
+		if err != nil {
+			return err
+		}
+		*e = NetworkID(rv)
+		return nil
 	}
 
 	// Fall back to the slower binary.Read if a fast path was not available
@@ -448,6 +456,13 @@ func writeElement(w io.Writer, element interface{}) error {
 		return nil
 
 	case RejectCode:
+		err := binarySerializer.PutUint8(w, uint8(e))
+		if err != nil {
+			return err
+		}
+		return nil
+
+	case NetworkID:
 		err := binarySerializer.PutUint8(w, uint8(e))
 		if err != nil {
 			return err

--- a/wire/message.go
+++ b/wire/message.go
@@ -32,6 +32,7 @@ const (
 	CmdVerAck       = "verack"
 	CmdGetAddr      = "getaddr"
 	CmdAddr         = "addr"
+	CmdAddrV2       = "addrv2"
 	CmdGetBlocks    = "getblocks"
 	CmdInv          = "inv"
 	CmdGetData      = "getdata"
@@ -108,6 +109,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdAddr:
 		msg = &MsgAddr{}
+
+	case CmdAddrV2:
+		msg = &MsgAddrV2{}
 
 	case CmdGetBlocks:
 		msg = &MsgGetBlocks{}

--- a/wire/msgaddr2_test.go
+++ b/wire/msgaddr2_test.go
@@ -1,0 +1,664 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// hexToBytes converts the passed hex string into bytes and will panic if there
+// is an error.  This is only provided for the hard-coded constants so errors in
+// the source code can be detected. It will only (and must only) be called with
+// hard-coded values.
+func hexToBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	return b
+}
+
+// TestAddrV2 tests the MsgAddrV2 API.
+func TestAddrV2(t *testing.T) {
+	pver := ProtocolVersion
+
+	// Ensure the command is expected value.
+	wantCmd := "addrv2"
+	msg := NewMsgAddrV2()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgAddrV2: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value for latest protocol version.
+	// Num addresses (varInt) + num * (time + services + networkID + addr len + addr + port)
+	wantPayload := uint32(9 + 1000*(4+9+1+9+512+2))
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Ensure NetAddresses are added properly.
+	tcpAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
+	na := NewNetAddressV2(tcpAddr, SFNodeNetwork)
+	err := msg.AddAddress(na)
+	if err != nil {
+		t.Errorf("AddAddress: %v", err)
+	}
+	if msg.AddrList[0] != na {
+		t.Errorf("AddAddress: wrong address added - got %v, want %v",
+			spew.Sprint(msg.AddrList[0]), spew.Sprint(na))
+	}
+
+	// Ensure the address list is cleared properly.
+	msg.ClearAddresses()
+	if len(msg.AddrList) != 0 {
+		t.Errorf("ClearAddresses: address list is not empty - "+
+			"got %v [%v], want %v", len(msg.AddrList),
+			spew.Sprint(msg.AddrList[0]), 0)
+	}
+
+	// Ensure adding more than the max allowed addresses per message returns
+	// error.
+	for i := 0; i < MaxAddrPerMsg+1; i++ {
+		err = msg.AddAddress(na)
+	}
+	if err == nil {
+		t.Errorf("AddAddress: expected error on too many addresses " +
+			"not received")
+	}
+	err = msg.AddAddresses(na)
+	if err == nil {
+		t.Errorf("AddAddresses: expected error on too many addresses " +
+			"not received")
+	}
+}
+
+// TestAddrV2Wire tests the MsgAddrV2 wire encode and decode for various numbers
+// of addresses and protocol versions.
+func TestAddrV2Wire(t *testing.T) {
+	// A couple of NetAddresses to use for testing.
+	na := &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("127.0.0.1").To4(),
+			Port:      8333,
+		},
+		NetworkID: NIIPV4,
+	}
+	na2 := &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("192.168.0.1").To4(),
+			Port:      8334,
+		},
+		NetworkID: NIIPV4,
+	}
+
+	// Empty address message.
+	noAddr := NewMsgAddrV2()
+	noAddrEncoded := []byte{
+		0x00, // Varint for number of addresses
+	}
+
+	// Address message with multiple addresses.
+	multiAddr := NewMsgAddrV2()
+	multiAddr.AddAddresses(na, na2)
+	multiAddrEncoded := []byte{
+		0x02,                   // Varint for number of addresses
+		0x29, 0xab, 0x5f, 0x49, // Timestamp
+		0x01,                   // services (CompactSize)
+		0x01,                   // networkID
+		0x04,                   // addr size (CompactSize)
+		0x7f, 0x00, 0x00, 0x01, // IP 127.0.0.1
+		0x20, 0x8d, // Port 8333 in big-endian
+		0x29, 0xab, 0x5f, 0x49, // Timestamp
+		0x01,                   // services (CompactSize)
+		0x01,                   // networkID
+		0x04,                   // addr size (CompactSize)
+		0xc0, 0xa8, 0x00, 0x01, // IP 192.168.0.1
+		0x20, 0x8e, // Port 8334 in big-endian
+	}
+
+	tests := []struct {
+		in   *MsgAddrV2      // Message to encode
+		out  *MsgAddrV2      // Expected decoded message
+		buf  []byte          // Wire encoding
+		pver uint32          // Protocol version for wire encoding
+		enc  MessageEncoding // Message encoding format
+	}{
+		// Latest protocol version with no addresses.
+		{
+			noAddr,
+			noAddr,
+			noAddrEncoded,
+			ProtocolVersion,
+			BaseEncoding,
+		},
+
+		// Latest protocol version with multiple addresses.
+		{
+			multiAddr,
+			multiAddr,
+			multiAddrEncoded,
+			ProtocolVersion,
+			BaseEncoding,
+		},
+
+		// Protocol version MultipleAddressVersion-1 with no addresses.
+		{
+			noAddr,
+			noAddr,
+			noAddrEncoded,
+			MultipleAddressVersion - 1,
+			BaseEncoding,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgAddrV2
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BtcDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}
+
+// TestAddrV2WireErrors performs negative tests against wire encode and decode
+// of MsgAddrV2 to confirm error paths work correctly.
+func TestAddrV2WireErrors(t *testing.T) {
+	pver := ProtocolVersion
+	wireErr := &MessageError{}
+
+	// A couple of NetAddresses to use for testing.
+	na := &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("127.0.0.1"),
+			Port:      8333,
+		},
+		NetworkID: NIIPV4,
+	}
+	na2 := &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("192.168.0.1"),
+			Port:      8334,
+		},
+		NetworkID: NIIPV4,
+	}
+
+	// Address message with multiple addresses.
+	baseAddr := NewMsgAddrV2()
+	baseAddr.AddAddresses(na, na2)
+	baseAddrEncoded := []byte{
+		0x02,                   // Varint for number of addresses
+		0x29, 0xab, 0x5f, 0x49, // Timestamp
+		0x01,                   // services (CompactSize)
+		0x01,                   // networkID
+		0x04,                   // addr size (CompactSize)
+		0x7f, 0x00, 0x00, 0x01, // IP 127.0.0.1
+		0x20, 0x8d, // Port 8333 in big-endian
+		0x29, 0xab, 0x5f, 0x49, // Timestamp
+		0x01,                   // services (CompactSize)
+		0x01,                   // networkID
+		0x04,                   // addr size (CompactSize)
+		0xc0, 0xa8, 0x00, 0x01, // IP 192.168.0.1
+		0x20, 0x8e, // Port 8334 in big-endian
+
+	}
+
+	// Message that forces an error by having more than the max allowed
+	// addresses.
+	maxAddr := NewMsgAddrV2()
+	for i := 0; i < MaxAddrPerMsg; i++ {
+		maxAddr.AddAddress(na)
+	}
+	maxAddr.AddrList = append(maxAddr.AddrList, na)
+	maxAddrEncoded := []byte{
+		0xfd, 0x03, 0xe9, // Varint for number of addresses (1001)
+	}
+
+	tests := []struct {
+		in       *MsgAddrV2      // Value to encode
+		buf      []byte          // Wire encoding
+		pver     uint32          // Protocol version for wire encoding
+		enc      MessageEncoding // Message encoding format
+		max      int             // Max size of fixed buffer to induce errors
+		writeErr error           // Expected write error
+		readErr  error           // Expected read error
+	}{
+		// Latest protocol version with intentional read/write errors.
+		// Force error in addresses count
+		{baseAddr, baseAddrEncoded, pver, BaseEncoding, 0, io.ErrShortWrite, io.EOF},
+		// Force error in address list.
+		{baseAddr, baseAddrEncoded, pver, BaseEncoding, 1, io.ErrShortWrite, io.EOF},
+		// Force error with greater than max inventory vectors.
+		{maxAddr, maxAddrEncoded, pver, BaseEncoding, 3, wireErr, wireErr},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode to wire format.
+		w := newFixedWriter(test.max)
+		err := test.in.BtcEncode(w, test.pver, test.enc)
+		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
+				i, err, test.writeErr)
+			continue
+		}
+
+		// For errors which are not of type MessageError, check them for
+		// equality.
+		if _, ok := err.(*MessageError); !ok {
+			if err != test.writeErr {
+				t.Errorf("BtcEncode #%d wrong error got: %v, "+
+					"want: %v", i, err, test.writeErr)
+				continue
+			}
+		}
+
+		// Decode from wire format.
+		var msg MsgAddr
+		r := newFixedReader(test.max, test.buf)
+		err = msg.BtcDecode(r, test.pver, test.enc)
+		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
+				i, err, test.readErr)
+			continue
+		}
+
+		// For errors which are not of type MessageError, check them for
+		// equality.
+		if _, ok := err.(*MessageError); !ok {
+			if err != test.readErr {
+				t.Errorf("BtcDecode #%d wrong error got: %v, "+
+					"want: %v", i, err, test.readErr)
+				continue
+			}
+		}
+
+	}
+}
+
+// TestAddrV2WireHex tests the MsgAddrV2 wire encode and decode for various numbers
+// of addresses and protocol versions.
+func TestAddrV2WireHex(t *testing.T) {
+
+	// Tests from https://github.com/ZcashFoundation/zebra/blob/afb8b3d4775d89b3f9223447341bf6ce152f5c3a/zebra-test/src/network_addr.rs#L87
+
+	// stream_addrv2_hex
+	msgAddrHex0 := hexToBytes(strings.Join([]string{
+		"03",                               // number of entries
+		"61bc6649",                         // time, Fri Jan  9 02:54:25 UTC 2009
+		"00",                               // service flags, COMPACTSIZE(NODE_NONE)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"0000",                             // port, 0
+
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"00f1",                             // port, 241
+
+		"79627683", // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",       // service flags, COMPACTSIZE(NODE_NETWORK)
+		"04",       // network id, TorV3
+		"20",       // address length, COMPACTSIZE(32)
+		"53cd5648488c4707914182655b7664034e09e66f7e8cbf1084e654eb56c5bd88",
+		// address, (32 byte Tor v3 onion service public key)
+		"235a", // port, 9050
+	}, ""))
+	msgAddr0 := NewMsgAddrV2()
+	msgAddr0.AddAddresses(&NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x4966bc61, 0),
+			Services:  0,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      0,
+		},
+		NetworkID: NIIPV6,
+	}, &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      241,
+		},
+		NetworkID: NIIPV6,
+	}, &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			Port:      9050,
+		},
+		NetworkID: NITorV3,
+		Addr:      hexToBytes("53cd5648488c4707914182655b7664034e09e66f7e8cbf1084e654eb56c5bd88"),
+	})
+
+	// IPv4
+	msgAddrHex1 := hexToBytes(strings.Join([]string{
+		"02", // number of entries
+
+		"79627683", // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",       // service flags, COMPACTSIZE(NODE_NETWORK)
+		"01",       // network id, IPv4
+		"04",       // address length, COMPACTSIZE(4)
+		"7f000001", // address, 127.0.0.1
+		"0001",     // port, 1
+
+		// check that variable-length encoding works
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"00f1",                             // port, 241
+	}, ""))
+	msgAddr1 := NewMsgAddrV2()
+	msgAddr1.AddAddresses(&NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("127.0.0.1").To4(),
+			Port:      1,
+		},
+		NetworkID: NIIPV4,
+	}, &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      241,
+		},
+		NetworkID: NIIPV6,
+	})
+
+	// all services flags set
+	msgAddrHex2 := hexToBytes(strings.Join([]string{
+		"01", // number of entries
+
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"ffffffffffffffffff",               // service flags, COMPACTSIZE(all flags set)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"0000",                             // port, 0
+	}, ""))
+	msgAddr2 := NewMsgAddrV2()
+	msgAddr2.AddAddresses(&NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  0xffffffffffffffff,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      0,
+		},
+		NetworkID: NIIPV6,
+	})
+
+	// Unknown Network ID: address within typical size range
+	msgAddrHex3 := hexToBytes(strings.Join([]string{
+		"02", // number of entries
+
+		"79627683",         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"fb",               // network id, (unknown)
+		"08",               // address length, COMPACTSIZE(8)
+		"0000000000000000", // address, (8 zero bytes)
+		"0001",             // port, 1
+
+		// check that variable-length encoding works
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"00f1",                             // port, 241
+	}, ""))
+	msgAddr3 := NewMsgAddrV2()
+	msgAddr3.AddAddresses(&NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			Port:      1,
+		},
+		Addr:      hexToBytes("0000000000000000"),
+		NetworkID: 0xfb,
+	}, &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      241,
+		},
+		NetworkID: NIIPV6,
+	})
+
+	// Unknown Network ID: zero-sized address
+	msgAddrHex4 := hexToBytes(strings.Join([]string{
+		"02", // number of entries
+
+		"79627683", // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",       // service flags, COMPACTSIZE(NODE_NETWORK)
+		"fc",       // network id, (unknown)
+		"00",       // address length, COMPACTSIZE(0)
+		"",         // address, (no bytes)
+		"0001",     // port, 1
+
+		// check that variable-length encoding works
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"00f1",                             // port, 241
+	}, ""))
+	msgAddr4 := NewMsgAddrV2()
+	msgAddr4.AddAddresses(&NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			Port:      1,
+		},
+		Addr:      []byte{},
+		NetworkID: 0xfc,
+	}, &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      241,
+		},
+		NetworkID: NIIPV6,
+	})
+
+	// Unknown Network ID: maximum-sized address
+	msgAddrHex5 := hexToBytes(strings.Join([]string{
+		"02", // number of entries
+
+		"79627683",                // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                      // service flags, COMPACTSIZE(NODE_NETWORK)
+		"fd",                      // network id, (unknown)
+		"fd0002",                  // address length, COMPACTSIZE(512)
+		strings.Repeat("00", 512), // address, (512 zero bytes)
+		"0001",                    // port, 1
+
+		// check that variable-length encoding works
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"00f1",                             // port, 241
+	}, ""))
+	msgAddr5 := NewMsgAddrV2()
+	msgAddr5.AddAddresses(&NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			Port:      1,
+		},
+		Addr:      bytes.Repeat([]byte{0x00}, 512),
+		NetworkID: 0xfd,
+	}, &NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x83766279, 0),
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("::1").To16(),
+			Port:      241,
+		},
+		NetworkID: NIIPV6,
+	})
+
+	// Empty list
+	msgAddrHex6 := hexToBytes(strings.Join([]string{
+		"00", // number of entries
+	}, ""))
+	msgAddr6 := NewMsgAddrV2()
+
+	tests := []struct {
+		in   *MsgAddrV2      // Message to encode
+		buf  []byte          // Wire encoding
+		pver uint32          // Protocol version for wire encoding
+		enc  MessageEncoding // Message encoding format
+	}{
+		{msgAddr0, msgAddrHex0, ProtocolVersion, BaseEncoding},
+		{msgAddr1, msgAddrHex1, ProtocolVersion, BaseEncoding},
+		{msgAddr2, msgAddrHex2, ProtocolVersion, BaseEncoding},
+		{msgAddr3, msgAddrHex3, ProtocolVersion, BaseEncoding},
+		{msgAddr4, msgAddrHex4, ProtocolVersion, BaseEncoding},
+		{msgAddr5, msgAddrHex5, ProtocolVersion, BaseEncoding},
+		{msgAddr6, msgAddrHex6, ProtocolVersion, BaseEncoding},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgAddrV2
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver, test.enc)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.in) {
+			t.Errorf("BtcDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.in))
+			continue
+		}
+	}
+}
+
+// TestAddrV2WireHexErrors performs negative tests against wire encode and decode
+// of MsgAddrV2 to confirm error paths work correctly.
+func TestAddrV2WireHexErrors(t *testing.T) {
+
+	// Tests from https://github.com/ZcashFoundation/zebra/blob/afb8b3d4775d89b3f9223447341bf6ce152f5c3a/zebra-test/src/network_addr.rs#L87
+
+	wireErr := &MessageError{}
+
+	// Invalid address size: too large, but under CompactSizeMessage limit
+	msgAddrHex0 := hexToBytes(strings.Join([]string{
+		"02", // number of entries
+
+		"79627683",                // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                      // service flags, COMPACTSIZE(NODE_NETWORK)
+		"fe",                      // network id, (unknown)
+		"fd0102",                  // invalid address length, COMPACTSIZE(513)
+		strings.Repeat("00", 513), // address, (513 zero bytes)
+		"0001",                    // port, 1
+
+		// check that the entire message is ignored
+		"79627683",                         // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",                               // service flags, COMPACTSIZE(NODE_NETWORK)
+		"02",                               // network id, IPv6
+		"10",                               // address length, COMPACTSIZE(16)
+		"00000000000000000000000000000001", // address, ::1
+		"00f1",                             // port, 241
+	}, ""))
+
+	// Invalid address size: too large, over CompactSizeMessage limit
+	msgAddrHex1 := hexToBytes(strings.Join([]string{
+		"01", // number of entries
+
+		"79627683",   // time, Tue Nov 22 11:22:33 UTC 2039
+		"01",         // service flags, COMPACTSIZE(NODE_NETWORK)
+		"ff",         // network id, (unknown)
+		"feffffff7f", // invalid address length, COMPACTSIZE(2^31 - 1)
+		// no address, generated bytes wouldn't fit in memory
+	}, ""))
+
+	tests := []struct {
+		buf     []byte          // Wire encoding
+		pver    uint32          // Protocol version for wire encoding
+		enc     MessageEncoding // Message encoding format
+		readErr error           // Expected read error
+	}{
+		{msgAddrHex0, ProtocolVersion, BaseEncoding, wireErr},
+		{msgAddrHex1, ProtocolVersion, BaseEncoding, wireErr},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Decode the message from wire format.
+		var msg MsgAddrV2
+		rbuf := bytes.NewReader(test.buf)
+		err := msg.BtcDecode(rbuf, test.pver, test.enc)
+		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
+				i, err, test.readErr)
+			continue
+		}
+	}
+}

--- a/wire/msgaddr2_test.go
+++ b/wire/msgaddr2_test.go
@@ -39,7 +39,7 @@ func TestAddrV2(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + num * (time + services + networkID + addr len + addr + port)
-	wantPayload := uint32(9 + 1000*(4+9+1+9+512+2))
+	wantPayload := uint32(9 + 1000*(4+9+1+3+512+2))
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgaddrv2.go
+++ b/wire/msgaddrv2.go
@@ -103,7 +103,7 @@ func (msg *MsgAddrV2) MaxPayloadLength(pver uint32) uint32 {
 	return MaxVarIntPayload + (MaxAddrPerMsg * maxNetAddressPayloadV2(pver))
 }
 
-// NewMsgAddrV2 returns a new bitcoin sendaddrv2 message that conforms to the
+// NewMsgAddrV2 returns a new bitcoin addrv2 message that conforms to the
 // Message interface.
 func NewMsgAddrV2() *MsgAddrV2 {
 	return &MsgAddrV2{

--- a/wire/msgaddrv2.go
+++ b/wire/msgaddrv2.go
@@ -1,0 +1,112 @@
+package wire
+
+import (
+	"fmt"
+	"io"
+)
+
+type MsgAddrV2 struct {
+	AddrList []*NetAddressV2
+}
+
+// AddAddress adds a known active peer to the message.
+func (msg *MsgAddrV2) AddAddress(na *NetAddressV2) error {
+	if len(msg.AddrList)+1 > MaxAddrPerMsg {
+		str := fmt.Sprintf("too many addresses in message [max %v]",
+			MaxAddrPerMsg)
+		return messageError("MsgAddrV2.AddAddress", str)
+	}
+
+	msg.AddrList = append(msg.AddrList, na)
+	return nil
+}
+
+// AddAddresses adds multiple known active peers to the message.
+func (msg *MsgAddrV2) AddAddresses(netAddrs ...*NetAddressV2) error {
+	for _, na := range netAddrs {
+		err := msg.AddAddress(na)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ClearAddresses removes all addresses from the message.
+func (msg *MsgAddrV2) ClearAddresses() {
+	msg.AddrList = []*NetAddressV2{}
+}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgAddrV2) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	count, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	// Limit to max addresses per message.
+	if count > MaxAddrPerMsg {
+		str := fmt.Sprintf("too many addresses for message "+
+			"[count %v, max %v]", count, MaxAddrPerMsg)
+		return messageError("MsgAddrV2.BtcDecode", str)
+	}
+
+	addrList := make([]NetAddressV2, count)
+	msg.AddrList = make([]*NetAddressV2, 0, count)
+	for i := uint64(0); i < count; i++ {
+		na := &addrList[i]
+		err := readNetAddressV2(r, pver, na)
+		if err != nil {
+			return err
+		}
+		msg.AddAddress(na)
+	}
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgAddrV2) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	count := len(msg.AddrList)
+	if count > MaxAddrPerMsg {
+		str := fmt.Sprintf("too many addresses for message "+
+			"[count %v, max %v]", count, MaxAddrPerMsg)
+		return messageError("MsgAddrV2.BtcEncode", str)
+	}
+
+	err := WriteVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+
+	for _, na := range msg.AddrList {
+		err = writeNetAddressV2(w, pver, na)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgAddrV2) Command() string {
+	return CmdAddrV2
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgAddrV2) MaxPayloadLength(pver uint32) uint32 {
+	// Num addresses (varInt) + max allowed addresses.
+	return MaxVarIntPayload + (MaxAddrPerMsg * maxNetAddressPayloadV2(pver))
+}
+
+// NewMsgAddrV2 returns a new bitcoin sendaddrv2 message that conforms to the
+// Message interface.
+func NewMsgAddrV2() *MsgAddrV2 {
+	return &MsgAddrV2{
+		AddrList: make([]*NetAddressV2, 0, MaxAddrPerMsg),
+	}
+}

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -1,0 +1,231 @@
+package wire
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// MaxAddrV2Size is the maximum size of an addresses in a bitcoin addrv2 message
+// (MsgAddrV2).
+const MaxAddrV2Size = 512
+
+// NetworkID specifies which network is addressed by the NetAddressV2 struct.
+type NetworkID byte
+
+const (
+	// NIIPV4 is a IPv4 address (globally routed internet)
+	NIIPV4 NetworkID = 0x01
+	// NIIPV6 is a IPv6 address (globally routed internet)
+	NIIPV6 NetworkID = 0x02
+	// NITorV2 is a Tor v2 hidden service address
+	NITorV2 NetworkID = 0x03
+	// NITorV3 is a Tor v3 hidden service address
+	NITorV3 NetworkID = 0x04
+	// NII2P is a NII2P overlay network address
+	NII2P NetworkID = 0x05
+	// NICjdns is a Cjdns overlay network address
+	NICjdns NetworkID = 0x06
+)
+
+var AddressSizeByNetworkID = map[NetworkID]uint64{
+	NIIPV4:  4,
+	NIIPV6:  16,
+	NITorV2: 10,
+	NITorV3: 32,
+	NII2P:   32,
+	NICjdns: 16,
+}
+
+// maxNetAddressPayloadV2 returns the max payload size for a bitcoin NetAddressV2
+// based on the protocol version.
+func maxNetAddressPayloadV2(pver uint32) uint32 {
+	// Timestamp 4 bytes
+	plen := uint32(4)
+	// services
+	plen += MaxVarIntPayload
+	// networkID
+	plen += 1
+	// address
+	plen += MaxVarIntPayload + MaxAddrV2Size
+	// port
+	plen += 2
+	return plen
+}
+
+// Return the NetworkID of the given IP address and its canonical form
+// (4-byte if IPV4, 16-byte if IPV6).
+func getNetworkID(ip net.IP) (net.IP, NetworkID) {
+	if ip.To4() != nil {
+		return ip.To4(), NIIPV4
+	} else {
+		return ip.To16(), NIIPV6
+	}
+}
+
+// NetAddressV2 defines information about a peer on the network including the time
+// it was last seen, the services it supports, its IP address, and port.
+type NetAddressV2 struct {
+	// NetAddress is the embedded version1 address.
+	NetAddress
+
+	// NetworkID specifies which network is addressed.
+	NetworkID NetworkID
+
+	// Addr is the raw address of the peer, if NetworkID is not IPV4 nor IPV6.
+	Addr []byte
+}
+
+// NewNetAddressV2IPPort returns a new NetAddressV2 using the provided IP, port, and
+// supported services with defaults for the remaining fields.
+func NewNetAddressV2IPPort(ip net.IP, port uint16, services ServiceFlag) *NetAddressV2 {
+	return NewNetAddressV2Timestamp(time.Now(), services, ip, port)
+}
+
+// NewNetAddressV2Timestamp returns a new NetAddressV2 using the provided
+// timestamp, IP, port, and supported services. The timestamp is rounded to
+// single second precision.
+func NewNetAddressV2Timestamp(
+	timestamp time.Time, services ServiceFlag, ip net.IP, port uint16) *NetAddressV2 {
+
+	ip, networkID := getNetworkID(ip)
+	// Limit the timestamp to one second precision since the protocol
+	// doesn't support better.
+	na := NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(timestamp.Unix(), 0),
+			Services:  services,
+			IP:        ip,
+			Port:      port,
+		},
+		NetworkID: networkID,
+	}
+	return &na
+}
+
+// NewNetAddressV2 returns a new NetAddressV2 using the provided TCP address and
+// supported services with defaults for the remaining fields.
+func NewNetAddressV2(addr *net.TCPAddr, services ServiceFlag) *NetAddressV2 {
+	return NewNetAddressV2IPPort(addr.IP, uint16(addr.Port), services)
+}
+
+// NewNetAddressV2NetAddress returns a new NetAddressV2 from the provided NetAddress.
+func NewNetAddressV2NetAddress(addr1 *NetAddress) *NetAddressV2 {
+	return NewNetAddressV2Timestamp(addr1.Timestamp, addr1.Services, addr1.IP, addr1.Port)
+}
+
+// readNetAddressV2 reads an encoded NetAddressV2 from r depending on the protocol
+// version.
+func readNetAddressV2(r io.Reader, pver uint32, na *NetAddressV2) error {
+	var networkID NetworkID
+
+	// NOTE: The bitcoin protocol uses a uint32 for the timestamp so it will
+	// stop working somewhere around 2106.
+	err := readElement(r, (*uint32Time)(&na.Timestamp))
+	if err != nil {
+		return err
+	}
+
+	services, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	na.Services = ServiceFlag(services)
+
+	err = readElements(r, &networkID)
+	if err != nil {
+		return err
+	}
+
+	sizeAddr, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if sizeAddr > MaxAddrV2Size {
+		str := fmt.Sprintf("addr in addrv2 message is too big "+
+			"[count %v, max %v]", sizeAddr, MaxAddrV2Size)
+		return messageError("readNetAddressV2", str)
+	}
+	correctSize, ok := AddressSizeByNetworkID[networkID]
+	// Unknown network IDs are allowed to be parsed.
+	if ok && sizeAddr != correctSize {
+		str := fmt.Sprintf("incorrect addr size in addrv2 message "+
+			"[size %v, expected %v]", sizeAddr, correctSize)
+		return messageError("readNetAddressV2", str)
+	}
+
+	var addr []byte = make([]byte, sizeAddr)
+	_, err = io.ReadFull(r, addr)
+	if err != nil {
+		return err
+	}
+
+	port, err := binarySerializer.Uint16(r, bigEndian)
+	if err != nil {
+		return err
+	}
+
+	*na = NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: na.Timestamp,
+			Services:  na.Services,
+			Port:      port,
+		},
+		NetworkID: networkID,
+	}
+
+	switch networkID {
+	case NIIPV4:
+		na.IP = net.IP(addr).To4()
+	case NIIPV6:
+		na.IP = net.IP(addr).To16()
+	default:
+		na.Addr = addr
+	}
+
+	return nil
+}
+
+// writeNetAddressV2 serializes a NetAddressV2 to w depending on the protocol
+// version.
+func writeNetAddressV2(w io.Writer, pver uint32, na *NetAddressV2) error {
+	// NOTE: The bitcoin protocol uses a uint32 for the timestamp so it will
+	// stop working somewhere around 2106.
+	err := writeElement(w, uint32(na.Timestamp.Unix()))
+	if err != nil {
+		return err
+	}
+
+	err = WriteVarInt(w, pver, uint64(na.Services))
+	if err != nil {
+		return err
+	}
+
+	var addr []byte
+	var networkID NetworkID
+	if len(na.IP) > 0 {
+		addr, networkID = getNetworkID(na.IP)
+	} else {
+		addr = na.Addr
+		networkID = na.NetworkID
+	}
+
+	err = writeElements(w, networkID)
+	if err != nil {
+		return err
+	}
+
+	err = WriteVarInt(w, pver, uint64(len(addr)))
+	if err != nil {
+		return err
+	}
+
+	err = writeElements(w, addr)
+	if err != nil {
+		return err
+	}
+
+	return binary.Write(w, bigEndian, na.Port)
+}

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -20,7 +20,9 @@ const (
 	NIIPV4 NetworkID = 0x01
 	// NIIPV6 is a IPv6 address (globally routed internet)
 	NIIPV6 NetworkID = 0x02
-	// NITorV2 is a Tor v2 hidden service address
+	// NITorV2 is a Tor v2 hidden service address.
+	// Disabled by Tor as of October 2021:
+	// https://support.torproject.org/onionservices/v2-deprecation/
 	NITorV2 NetworkID = 0x03
 	// NITorV3 is a Tor v3 hidden service address
 	NITorV3 NetworkID = 0x04

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -51,7 +51,10 @@ func maxNetAddressPayloadV2(pver uint32) uint32 {
 	// networkID
 	plen += 1
 	// address
-	plen += MaxVarIntPayload + MaxAddrV2Size
+	// We use 3 instead of MaxVarIntPayload because of MaxAddrV2Size limit,
+	// which forces the CompactSize prefix to have at most 3 bytes
+	// (1 byte length selection prefix, plus a 2 byte integer).
+	plen += 3 + MaxAddrV2Size
 	// port
 	plen += 2
 	return plen

--- a/wire/netaddressv2_test.go
+++ b/wire/netaddressv2_test.go
@@ -51,7 +51,7 @@ func TestNetAddressV2(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	pver := ProtocolVersion
-	wantPayload := uint32(512 + 25)
+	wantPayload := uint32(512 + 19)
 	maxPayload := maxNetAddressPayloadV2(ProtocolVersion)
 	if maxPayload != wantPayload {
 		t.Errorf("maxNetAddressPayloadV2: wrong max payload length for "+

--- a/wire/netaddressv2_test.go
+++ b/wire/netaddressv2_test.go
@@ -1,0 +1,211 @@
+package wire
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TestNetAddressV2 tests the NetAddress API.
+func TestNetAddressV2(t *testing.T) {
+	ip := net.ParseIP("127.0.0.1")
+	port := 8333
+
+	// Test NewNetAddressV2.
+	na := NewNetAddressV2(&net.TCPAddr{IP: ip, Port: port}, 0)
+
+	// Ensure we get the same ip, port, and services back out.
+	if !na.IP.Equal(ip) {
+		t.Errorf("NetNetAddressV2: wrong ip - got %v, want %v", na.IP, ip)
+	}
+	if na.Port != uint16(port) {
+		t.Errorf("NetNetAddressV2: wrong port - got %v, want %v", na.Port,
+			port)
+	}
+	if na.Services != 0 {
+		t.Errorf("NetNetAddressV2: wrong services - got %v, want %v",
+			na.Services, 0)
+	}
+	if na.NetworkID != NIIPV4 {
+		t.Errorf("NetNetAddressV2: wrong NetworkID - got %v, want %v",
+			na.NetworkID, NIIPV4)
+	}
+	if na.HasService(SFNodeNetwork) {
+		t.Errorf("HasService: SFNodeNetwork service is set")
+	}
+
+	// Ensure adding the full service node flag works.
+	na.AddService(SFNodeNetwork)
+	if na.Services != SFNodeNetwork {
+		t.Errorf("AddService: wrong services - got %v, want %v",
+			na.Services, SFNodeNetwork)
+	}
+	if !na.HasService(SFNodeNetwork) {
+		t.Errorf("HasService: SFNodeNetwork service not set")
+	}
+
+	// Ensure max payload is expected value for latest protocol version.
+	pver := ProtocolVersion
+	wantPayload := uint32(512 + 25)
+	maxPayload := maxNetAddressPayloadV2(ProtocolVersion)
+	if maxPayload != wantPayload {
+		t.Errorf("maxNetAddressPayloadV2: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+}
+
+// TestNetAddressWireV2 tests the NetAddress wire encode and decode for various
+// protocol versions and timestamp flag combinations.
+func TestNetAddressWireV2(t *testing.T) {
+	// baseNetAddr is used in the various tests as a baseline NetAddress.
+	baseNetAddr := NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("127.0.0.1").To4(),
+			Port:      8333,
+		},
+		NetworkID: NIIPV4,
+	}
+
+	// baseNetAddrNoTS is baseNetAddr with a zero value for the timestamp.
+	baseNetAddrNoTS := baseNetAddr
+	baseNetAddrNoTS.Timestamp = time.Time{}
+
+	// baseNetAddrEncoded is the wire encoded bytes of baseNetAddr.
+	baseNetAddrEncoded := []byte{
+		0x29, 0xab, 0x5f, 0x49, // Timestamp
+		0x01,                   // SFNodeNetwork
+		0x01,                   // IPV4
+		0x04,                   // addr size
+		0x7f, 0x00, 0x00, 0x01, // IP 127.0.0.1
+		0x20, 0x8d, // Port 8333 in big-endian
+	}
+
+	tests := []struct {
+		in   NetAddressV2 // NetAddress to encode
+		out  NetAddressV2 // Expected decoded NetAddress
+		buf  []byte       // Wire encoding
+		pver uint32       // Protocol version for wire encoding
+	}{
+		// Latest protocol version with ts flag.
+		{
+			baseNetAddr,
+			baseNetAddr,
+			baseNetAddrEncoded,
+			ProtocolVersion,
+		},
+
+		// Protocol version NetAddressTimeVersion with ts flag.
+		{
+			baseNetAddr,
+			baseNetAddr,
+			baseNetAddrEncoded,
+			NetAddressTimeVersion,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode to wire format.
+		var buf bytes.Buffer
+		err := writeNetAddressV2(&buf, test.pver, &test.in)
+		if err != nil {
+			t.Errorf("writeNetAddressV2 #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("writeNetAddressV2 #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var na NetAddressV2
+		rbuf := bytes.NewReader(test.buf)
+		err = readNetAddressV2(rbuf, test.pver, &na)
+		if err != nil {
+			t.Errorf("readNetAddressV2 #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(na, test.out) {
+			t.Errorf("readNetAddressV2 #%d\n got: %s want: %s", i,
+				spew.Sdump(na), spew.Sdump(test.out))
+			continue
+		}
+	}
+}
+
+// TestNetAddressV2WireErrors performs negative tests against wire encode and
+// decode NetAddress to confirm error paths work correctly.
+func TestNetAddressV2WireErrors(t *testing.T) {
+	pver := ProtocolVersion
+
+	// baseNetAddr is used in the various tests as a baseline NetAddress.
+	baseNetAddr := NetAddressV2{
+		NetAddress: NetAddress{
+			Timestamp: time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST
+			Services:  SFNodeNetwork,
+			IP:        net.ParseIP("127.0.0.1"),
+			Port:      8333,
+		},
+		NetworkID: NIIPV4,
+	}
+
+	tests := []struct {
+		in       *NetAddressV2 // Value to encode
+		buf      []byte        // Wire encoding
+		pver     uint32        // Protocol version for wire encoding
+		max      int           // Max size of fixed buffer to induce errors
+		writeErr error         // Expected write error
+		readErr  error         // Expected read error
+	}{
+		// Latest protocol version with timestamp and intentional
+		// read/write errors.
+		// Force errors on timestamp.
+		{&baseNetAddr, []byte{}, pver, 0, io.ErrShortWrite, io.EOF},
+		// Force errors on services.
+		{&baseNetAddr, []byte{}, pver, 4, io.ErrShortWrite, io.EOF},
+		// Force errors on networkID.
+		{&baseNetAddr, []byte{}, pver, 5, io.ErrShortWrite, io.EOF},
+		// Force errors on address.
+		{&baseNetAddr, []byte{}, pver, 6, io.ErrShortWrite, io.EOF},
+		// Force errors on port.
+		{&baseNetAddr, []byte{}, pver, 11, io.ErrShortWrite, io.EOF},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode to wire format.
+		w := newFixedWriter(test.max)
+		err := writeNetAddressV2(w, test.pver, test.in)
+		if err != test.writeErr {
+			t.Errorf("writeNetAddressV2 #%d wrong error got: %v, want: %v",
+				i, err, test.writeErr)
+			continue
+		}
+
+		buf := new(bytes.Buffer)
+		err = writeNetAddressV2(buf, test.pver, test.in)
+		if err != nil {
+			t.Errorf("writeNetAddressV2 failed: %v", err)
+			continue
+		}
+
+		// Decode from wire format.
+		var na NetAddressV2
+		r := newFixedReader(test.max, buf.Bytes())
+		err = readNetAddressV2(r, test.pver, &na)
+		if err != test.readErr {
+			t.Errorf("readNetAddressV2 #%d wrong error got: %v, want: %v",
+				i, err, test.readErr)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
After Nu5 `addrv2` messages can be sent in the network. Therefore, the DNS seeder must be able to accept them.

This adds support for receiving `addrv2` messages. The implementation should work with Bitcoin too. (We can consider opening a PR in the upstream, but they'll probably want remaining logic of keeping track of `sendaddrv2` and actually sending `addrv2` messages)

Note: I created a `main-zfnd` branch from the last `btcd` tag (`v0.22.0-beta`) and set it as the default branch. This way it will be easier to sync from upstream if ever needed. Let me know if that makes sense.

Part of https://github.com/ZcashFoundation/zebra/issues/2882